### PR TITLE
Changed behaviour to accept images once they have been shared with the tenant

### DIFF
--- a/atrope/dispatcher/glance.py
+++ b/atrope/dispatcher/glance.py
@@ -323,6 +323,7 @@ class Dispatcher(base.BaseDispatcher):
             if tenant is not None:
                 try:
                     self.client.image_members.create(glance_image.id, tenant)
+		    self.client.image_members.update(glance_image.id, tenant, 'accepted')
                 except glance_exc.HTTPConflict:
                     pass
                 LOG.info("Image '%s' associated with VO '%s', tenant '%s'",


### PR DESCRIPTION
Under Newton and Glance APIv2, in order to use an image which has been shared from another tenant, a user with administrative privileges must accept it. This pull request solves this issue by changing the status from "pending" to "accepted" after the image has been shared from one tenant to another